### PR TITLE
Slider default

### DIFF
--- a/Examples/01_UIElements.vl
+++ b/Examples/01_UIElements.vl
@@ -217,7 +217,7 @@
               <p:sliderdirection p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.SliderDirectionEnum">Horizontal</p:sliderdirection>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="VETMlfN5liVPBdPoLYldoD" Comment="" Bounds="1433,199,108,35" ShowValueBox="true" isIOBox="true" Value="0.58">
+          <Pad Id="VETMlfN5liVPBdPoLYldoD" Comment="" Bounds="1433,199,108,35" ShowValueBox="true" isIOBox="true" Value="0.28">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
@@ -228,7 +228,7 @@
               <p:sliderdirection p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.SliderDirectionEnum">Horizontal</p:sliderdirection>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="M4c3rhFACsjL6QBVe4EzXH" Comment="" Bounds="1139,199,50,23" ShowValueBox="true" isIOBox="true" Value="foo">
+          <Pad Id="M4c3rhFACsjL6QBVe4EzXH" Comment="" Bounds="1139,199,50,23" ShowValueBox="true" isIOBox="true" Value="fi">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -397,7 +397,7 @@
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Renderer" />
             </p:NodeReference>
-            <Pin Id="Kh9yBi3OEd5MvWP8UR1lL8" Name="Bounds" Kind="InputPin" DefaultValue="822, 56, 600, 400">
+            <Pin Id="Kh9yBi3OEd5MvWP8UR1lL8" Name="Bounds" Kind="InputPin" DefaultValue="-1050, 189, 600, 400">
               <p:TypeAnnotation LastCategoryFullName="System.Drawing" LastSymbolSource="System.Drawing.dll">
                 <Choice Kind="TypeFlag" Name="Rectangle" />
               </p:TypeAnnotation>

--- a/Examples/02_UIElements_Spreading.vl
+++ b/Examples/02_UIElements_Spreading.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="EPI39uwpPiXPUg9niil4GQ" LanguageVersion="2019.1.0-0287-g67d678e5a2" Version="0.128">
+<Document xmlns:p="property" Id="EPI39uwpPiXPUg9niil4GQ" LanguageVersion="2019.1.0-0318-g91ff9a39a4" Version="0.128">
   <NugetDependency Id="TRCPOpT8dPAMMeZTNlDFbj" Location="VL.CoreLib" Version="2019.1.0-287" />
   <Patch Id="Gd72XSXDM2tPl9JwGR5zWo">
     <Canvas Id="KUZVH6zF0B2PQtq5PLbTag" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
@@ -44,9 +44,9 @@
               <Patch Id="CZ2zvHmxLYZMpk6ouy5RR4" Name="Update" ManuallySortedPins="true" />
               <Patch Id="SPdpg9vhYRCLsxEZP2kVDq" Name="Dispose" ManuallySortedPins="true" />
               <Node Bounds="1080,642,175,19" Id="MgdEFhJy9E8LgxiDkL7szf">
-                <p:NodeReference LastCategoryFullName="Main" LastSymbolSource="UIElements.vl">
+                <p:NodeReference LastCategoryFullName="VL.UIElements" LastSymbolSource="UIElements.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="UISlider" />
+                  <Choice Kind="ProcessAppFlag" Name="Slider" />
                 </p:NodeReference>
                 <Pin Id="NbjEom1Wx8cO2l7FfUmiei" Name="Bounds" Kind="InputPin" />
                 <Pin Id="VIn2HQasHRGM7deKNN5pBO" Name="Value" Kind="InputPin">
@@ -181,9 +181,9 @@
               <Patch Id="A0Gby4Ju7ZrLxI0fhQ16EB" Name="Update" ManuallySortedPins="true" />
               <Patch Id="SlEXO3sLH0HNHhtQl7nzn4" Name="Dispose" ManuallySortedPins="true" />
               <Node Bounds="719,644,175,19" Id="G5ePqflmFcqP67E2G3ELFD">
-                <p:NodeReference LastCategoryFullName="Main" LastSymbolSource="UIElements.vl">
+                <p:NodeReference LastCategoryFullName="VL.UIElements" LastSymbolSource="UIElements.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="UILabel" />
+                  <Choice Kind="ProcessAppFlag" Name="Label" />
                 </p:NodeReference>
                 <Pin Id="CHLSMsqnufrNgwajO9jQIO" Name="Bounds" Kind="InputPin" />
                 <Pin Id="MzPhHCQe3qwNkBFAc2AkKc" Name="Value" Kind="InputPin">
@@ -326,21 +326,6 @@
               <Patch Id="MTPQjlOEt0aL4MprjVkxaH" Name="Create" ManuallySortedPins="true" />
               <Patch Id="Q6CUK8NEHSlQZ0Fpy9oUAv" Name="Update" ManuallySortedPins="true" />
               <Patch Id="KLFLUHwRnKlLTItu6tU413" Name="Dispose" ManuallySortedPins="true" />
-              <Node Bounds="-299,647,175,19" Id="ULuAc0wsuWVO9YZozjDdmP">
-                <p:NodeReference LastCategoryFullName="Main" LastSymbolSource="UIElements.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="UIToggle" />
-                </p:NodeReference>
-                <Pin Id="MTWMLlPGdguOOfkaCDq4Ae" Name="Bounds" Kind="InputPin" />
-                <Pin Id="CMgy7AoRnIKOo70SzROKoP" Name="Value" Kind="InputPin">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                    <Choice Kind="TypeFlag" Name="Float32" />
-                  </p:TypeAnnotation>
-                </Pin>
-                <Pin Id="FgsoU7jFfNFMZ2ifQfzbGu" Name="Layer" Kind="OutputPin" />
-                <Pin Id="Q0svhRWlIqjNEGJKgs0VEk" Name="On Interaction" Kind="OutputPin" />
-                <Pin Id="Lkky7V2e7gJLuy8RnCZurW" Name="Value" Kind="OutputPin" />
-              </Node>
               <Node Bounds="-299,613,85,19" Id="Rj3JFPU9MP2N5JDChmSRmE">
                 <p:NodeReference LastCategoryFullName="2D.Rectangle" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -368,6 +353,18 @@
                 </Pin>
                 <Pin Id="FOQ5MbgnYlRPqafyYEUiya" Name="Anchor" Kind="InputPin" />
                 <Pin Id="L4vVa5b86G4NeB0FoX4rGw" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Node Bounds="-299,644,175,19" Id="ApXFK1mTAlwPZzNHc15DZ7">
+                <p:NodeReference LastCategoryFullName="VL.UIElements" LastSymbolSource="UIElements.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="Toggle" />
+                  <CategoryReference Kind="Category" Name="UIElements" NeedsToBeDirectParent="true" />
+                </p:NodeReference>
+                <Pin Id="UNdipVJ1v1oLDlQjPJrwNQ" Name="Bounds" Kind="InputPin" />
+                <Pin Id="DOFHfQlOqCHNYCvIK7xLOy" Name="Value" Kind="InputPin" />
+                <Pin Id="ASzdwdQqTOEMVMcicwUJaX" Name="Layer" Kind="OutputPin" />
+                <Pin Id="B4tCOZ3ro2bO6lj5jvvOPp" Name="On Interaction" Kind="OutputPin" />
+                <Pin Id="FA3KVbVasNSOjp1GFe4Z3R" Name="Value" Kind="OutputPin" />
               </Node>
             </Patch>
             <ControlPoint Id="LVfSIOwdaW0MzDHVMUX1Eg" Bounds="-276,596" Alignment="Top" />
@@ -497,7 +494,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="FYvtQvzmPelOVOXiPYDiN7" Comment="" Bounds="192,791,35,35" ShowValueBox="true" isIOBox="true" />
-          <Node Bounds="33,589,201,100" Id="DDj1rya573rMaUHwEQ9cgt">
+          <Node Bounds="33,590,201,100" Id="DDj1rya573rMaUHwEQ9cgt">
             <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               <FullNameCategoryReference ID="Primitive" />
@@ -508,21 +505,6 @@
               <Patch Id="BgwvxBQWM2aLCwNEQnKH0K" Name="Create" ManuallySortedPins="true" />
               <Patch Id="D0w6a3V9cDPMukHejUQm9B" Name="Update" ManuallySortedPins="true" />
               <Patch Id="Vu25EjX2MdsPS4LhEFOb1C" Name="Dispose" ManuallySortedPins="true" />
-              <Node Bounds="45,647,175,19" Id="F613xYCdt4NOZejTCE6Tyt">
-                <p:NodeReference LastCategoryFullName="Main" LastSymbolSource="UIElements.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="UIPress" />
-                </p:NodeReference>
-                <Pin Id="E1SjmM2UFUXL7bQI2nlXIg" Name="Bounds" Kind="InputPin" />
-                <Pin Id="DDTz68Y8Qs4OAPnYEKEjVE" Name="Value" Kind="InputPin">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                    <Choice Kind="TypeFlag" Name="Float32" />
-                  </p:TypeAnnotation>
-                </Pin>
-                <Pin Id="BqkjL4PqC7QM5iuXPn4Rts" Name="Layer" Kind="OutputPin" />
-                <Pin Id="TntYI21pEgsQScfZydLjXt" Name="On Interaction" Kind="OutputPin" />
-                <Pin Id="Ocx6eDI9xTsNSKoY71WCBN" Name="Value" Kind="OutputPin" />
-              </Node>
               <Node Bounds="45,613,85,19" Id="B5LxQJdK0jfLrgNusHCXIo">
                 <p:NodeReference LastCategoryFullName="2D.Rectangle" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -550,6 +532,17 @@
                 </Pin>
                 <Pin Id="UO3dNKMTHGTP14EnC14iQB" Name="Anchor" Kind="InputPin" />
                 <Pin Id="IksjG8zTtGMOYHB7Du5dkG" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Node Bounds="45,642,176,19" Id="Oj6IJaRfSQMPg3myoz1XUw">
+                <p:NodeReference LastCategoryFullName="VL.UIElements" LastSymbolSource="UIElements.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="Press" />
+                </p:NodeReference>
+                <Pin Id="IJNJowfo5yQMBSXRdMas78" Name="Bounds" Kind="InputPin" />
+                <Pin Id="Ltp5MfucjpvM5JZJfagYNq" Name="Value" Kind="InputPin" />
+                <Pin Id="OUdqy4sOlcZM9btByDek29" Name="Layer" Kind="OutputPin" />
+                <Pin Id="P1Dw8jjhz4cMsHTFLSobev" Name="On Interaction" Kind="OutputPin" />
+                <Pin Id="BUgM2Z6hdHsMlwefHyxvag" Name="Value" Kind="OutputPin" />
               </Node>
             </Patch>
             <ControlPoint Id="EXdfvDAa3BdNYjfr6kwweX" Bounds="68,596" Alignment="Top" />
@@ -639,9 +632,9 @@
               <Patch Id="BCrIwe3IsAhOZzLAeoFQ70" Name="Update" ManuallySortedPins="true" />
               <Patch Id="KzWwj3RJtxLOvmqOJTvWbx" Name="Dispose" ManuallySortedPins="true" />
               <Node Bounds="379,648,175,19" Id="HaY4QrqqGd7OftpVqD5LSO">
-                <p:NodeReference LastCategoryFullName="Main" LastSymbolSource="UIElements.vl">
+                <p:NodeReference LastCategoryFullName="VL.UIElements" LastSymbolSource="UIElements.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="UIBang" />
+                  <Choice Kind="ProcessAppFlag" Name="Bang" />
                 </p:NodeReference>
                 <Pin Id="SHhunbDZUVhQcWrvUTr8LR" Name="Bounds" Kind="InputPin" />
                 <Pin Id="L8h5kqBGewROscO4zLG0tn" Name="Value" Kind="InputPin">
@@ -750,11 +743,6 @@
         </Canvas>
         <Patch Id="H5Et2eHhtUQNF2rf3kKLy4" Name="Create" />
         <Patch Id="Qexb1laUmjcMjoGF4r1rT0" Name="Update" />
-        <!--
-
-    ************************  ************************
-
--->
         <ProcessDefinition Id="JYWaoZepSGWLf9SZwx0opv">
           <Fragment Id="KD2W1nglCAINEq63XBWt3s" Patch="H5Et2eHhtUQNF2rf3kKLy4" Enabled="true" />
           <Fragment Id="Nk68gL8HpCGNBh7fCxTHa9" Patch="Qexb1laUmjcMjoGF4r1rT0" Enabled="true" />
@@ -790,15 +778,10 @@
         <Link Id="Lt9mbuZ9ptdODQEh8Put84" Ids="IZbvI7T88QGPqM95N8B8BU,ScCI0WyqWggPczQzjn6GwK" />
         <Link Id="AYXazNwJ3CTNQCyfSntZBr" Ids="CCOXwUGu7WWOAOfAg4W1QC,UeJ2DY2TA8yO74o0JzvJoM" />
         <Link Id="T4yxHWt7nNSOQwPS1Ec0Yd" Ids="IkMbjEHQGCILaYXC6zY4CK,PBIBVJ76ulfNrFihNtRWBh" />
-        <Link Id="KbJkbbNRCW9P7S7zbWBOpp" Ids="L4vVa5b86G4NeB0FoX4rGw,MTWMLlPGdguOOfkaCDq4Ae" />
         <Link Id="QL15vHql3roPaEwmXGvvL5" Ids="LVfSIOwdaW0MzDHVMUX1Eg,MXcKHw1I0PJNF6Tb3pqHRE" />
-        <Link Id="N8Tj7JRqaYwQJeZmjGkwoI" Ids="FgsoU7jFfNFMZ2ifQfzbGu,TGDjiyVMHvbNigI1rqxz22" />
         <Link Id="FXulS4EtvTfLPPrwjL3aa6" Ids="TGDjiyVMHvbNigI1rqxz22,DF4jpuDCJIUNGzLKPPSu6s" />
-        <Link Id="Ss6FYwdqKEtMw64TnLmQ6S" Ids="Q0svhRWlIqjNEGJKgs0VEk,Ln045piz5b5NST423ZyvP3" />
-        <Link Id="NHyioHp94GmLNhfow0YKv8" Ids="Lkky7V2e7gJLuy8RnCZurW,QUWtdroOdJ0MCtU6YQ8dMD" />
         <Link Id="G6VjsDgcsmnPQswAv35uTi" Ids="Ln045piz5b5NST423ZyvP3,OSkJRdKY6eXN28R15qbwej" />
         <Link Id="TqQPa61Uk7DMLOVOx1RrLq" Ids="TeHFplVURJKNjA73gcR8Ia,TJw500DzF8TPa0MBEvHMqZ" />
-        <Link Id="Me3YhzsmVCAPKARmqFcPET" Ids="Fp09jJYeR3HNmhpBszsJhM,CMgy7AoRnIKOo70SzROKoP" />
         <Link Id="O6LqtL9NO4yQXD6nKpVXoz" Ids="Olgu4dmCipeMp66DflDRj6,Fp09jJYeR3HNmhpBszsJhM" />
         <Link Id="L62aGKnGwhLL3TqavEfe2i" Ids="QUWtdroOdJ0MCtU6YQ8dMD,CO6AWvxkSGCQMhqMBfeDKn" />
         <Link Id="QBAUeyi2CbNPqrVPGtDJF5" Ids="GM0JUdla0hdM6GSDrwSok7,LVfSIOwdaW0MzDHVMUX1Eg" />
@@ -809,15 +792,10 @@
         <Link Id="VPFEeaAh3NOOtylL3AmVL1" Ids="CagNHv8f9I1MjYzQikQHdp,U8lW22BPT4RNoyQwzb8jMW" />
         <Link Id="AKXUiDNIhQ4O9e7qPmeh8G" Ids="RuA1cqixZIXLz6BNEi18jX,Tjk56yDRhqrPjiXbvaSRGi" />
         <Link Id="KmwvaVcOzoXPZDeWS2yrdi" Ids="RCTtcPK89tUQFBpNnSfHN4,FYvtQvzmPelOVOXiPYDiN7" />
-        <Link Id="VQdWESJvJZ3LQVXi9GqqcA" Ids="IksjG8zTtGMOYHB7Du5dkG,E1SjmM2UFUXL7bQI2nlXIg" />
         <Link Id="F9T4Wu5PaU2MDgG5xd8YQ1" Ids="EXdfvDAa3BdNYjfr6kwweX,BrGlafKm5cQMyf9OK9r4dR" />
-        <Link Id="KmEE30FKha9MPh3Zw4YGIh" Ids="BqkjL4PqC7QM5iuXPn4Rts,BBXFwXfZGOBQFrLpKHCPjN" />
         <Link Id="IpYFrm3HUJPMtChmgpdB0l" Ids="BBXFwXfZGOBQFrLpKHCPjN,EcMQ1MUwZN3Nv8YxLOlrlN" />
-        <Link Id="TZvo1furfDmLchZnGoSlKr" Ids="TntYI21pEgsQScfZydLjXt,CZBLTxdb2y8M2ayOP6VN3d" />
-        <Link Id="FLjSuFm5iRkLjyzUnLMz0v" Ids="Ocx6eDI9xTsNSKoY71WCBN,Njig9CZc3f6N2rBT5YTini" />
         <Link Id="EyL06Qqg9qDNg54BfOiKQV" Ids="CZBLTxdb2y8M2ayOP6VN3d,U2U55jjUOx8LeQjDyQEP6S" />
         <Link Id="SnUMTuAAJZdQVJe2Eftqun" Ids="IsMsP7wOgT7Mn4ai1LJi1K,J6k8vP8UVIAMtBdqpeH0MZ" />
-        <Link Id="UdUJN7LdyebPfZnYPThFIV" Ids="Mm60qvwcLzCQWx0a9yqE9j,DDTz68Y8Qs4OAPnYEKEjVE" />
         <Link Id="KEbhwS8OPi6LnmVqMG4cNb" Ids="VpXEDbB2AbDLxF44u7etZh,Mm60qvwcLzCQWx0a9yqE9j" />
         <Link Id="PrMI22gbyjlNnNMnOPBZpg" Ids="VjbPrnZ5Tw4M8iXbAudI7V,PQOSjVCzotbP6ZB1Lw5oQ7" />
         <Link Id="HHPiQDizDtnOjeLU7llArI" Ids="Njig9CZc3f6N2rBT5YTini,CTdnZq0LcSQNaEFpBVb1o4" />
@@ -841,6 +819,16 @@
         <Link Id="JzIerv8zDl2NulCFNlGbTl" Ids="T21579nAdDIPAFO5L5LjNg,EPhPpMqfWY8MdBMu4EWDbQ" />
         <Link Id="Nvr9XKngoE5OZYG7LlwV8U" Ids="Fv5tvUZjVDGMYdeSC8L1fJ,TyoaIMsgxNePfRvae1m7fB" />
         <Link Id="F8PaUjP2eH4LAK9GB4S7zl" Ids="GM0JUdla0hdM6GSDrwSok7,Efvvw6zUDq5Pk2RBF6PEgO" />
+        <Link Id="SdW8AhGkH6BNMffSq6akEI" Ids="L4vVa5b86G4NeB0FoX4rGw,UNdipVJ1v1oLDlQjPJrwNQ" />
+        <Link Id="JXVCnBMYLGPMD3UGQ5bB9q" Ids="Fp09jJYeR3HNmhpBszsJhM,DOFHfQlOqCHNYCvIK7xLOy" />
+        <Link Id="HUhnclHevZbLZsgdwewpkZ" Ids="FA3KVbVasNSOjp1GFe4Z3R,QUWtdroOdJ0MCtU6YQ8dMD" />
+        <Link Id="P7KOh6MhIzWOp4laRNGPsc" Ids="B4tCOZ3ro2bO6lj5jvvOPp,Ln045piz5b5NST423ZyvP3" />
+        <Link Id="S1c2glXw0yFNe5a0meUtVX" Ids="ASzdwdQqTOEMVMcicwUJaX,TGDjiyVMHvbNigI1rqxz22" />
+        <Link Id="K0XfgZ3QrFSOqi9Gq2afdQ" Ids="IksjG8zTtGMOYHB7Du5dkG,IJNJowfo5yQMBSXRdMas78" />
+        <Link Id="Pocx22x5F4hP5x8CfL60TI" Ids="Mm60qvwcLzCQWx0a9yqE9j,Ltp5MfucjpvM5JZJfagYNq" />
+        <Link Id="P3RsNEHCkv1Pzl3hoq3h63" Ids="BUgM2Z6hdHsMlwefHyxvag,Njig9CZc3f6N2rBT5YTini" />
+        <Link Id="D0eQRFTbfHbLrFJHsdBBGx" Ids="P1Dw8jjhz4cMsHTFLSobev,CZBLTxdb2y8M2ayOP6VN3d" />
+        <Link Id="CzCwp7esaOgLZo17z5rVEe" Ids="OUdqy4sOlcZM9btByDek29,BBXFwXfZGOBQFrLpKHCPjN" />
       </Patch>
     </Node>
   </Patch>

--- a/vl/UIElements.vl
+++ b/vl/UIElements.vl
@@ -1472,8 +1472,7 @@
                   <ControlPoint Id="F8HYkchzbL3PFWsRNWK7qI" Bounds="735,248" />
                   <ControlPoint Id="Gg5czGma29WMSd06KX72QY" Bounds="518,472" />
                   <ControlPoint Id="Q01nfPYCvPfPY2tugTj8Dc" Bounds="662,472" />
-                  <ControlPoint Id="RIfkH13QPg0NO36o8pZemA" Bounds="858,472" />
-                  <ControlPoint Id="UV07Pzq3wTrPZbH8jZem6n" Bounds="1028,472" />
+                  <ControlPoint Id="UV07Pzq3wTrPZbH8jZem6n" Bounds="788,472" />
                   <Node Bounds="660,514,106,26" Id="N4FIEu02GJzNwwmEmU5UhA">
                     <p:NodeReference LastCategoryFullName="VL.UIElements.Utils.MouseState" LastSymbolSource="UIElements.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -1511,7 +1510,7 @@
                       </Node>
                     </Patch>
                   </Node>
-                  <Pad Id="M2gAsV8stT7MBI3RLjNg9u" SlotId="RzaKFt2UDs5MyNLtUTnjJh" Bounds="815,579" />
+                  <Pad Id="M2gAsV8stT7MBI3RLjNg9u" SlotId="RzaKFt2UDs5MyNLtUTnjJh" Bounds="814,586" />
                   <Node Bounds="465,546" Id="Oezl0wq5bGTMAR4OrBcfZc">
                     <p:NodeReference LastCategoryFullName="VL.UIElements.SliderProperties" LastSymbolSource="UIElements.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -1537,6 +1536,9 @@
                     <Pin Id="Gm3BFNB119hNbrkOEkgQVq" Name="Value" Kind="InputPin" />
                     <Pin Id="BQz26ttKiJ3Ox9fp78UQGh" Name="Output" Kind="StateOutputPin" />
                   </Node>
+                  <Pad Id="STDQDJfemU7L6tdkyBdQpl" SlotId="IEKTIpvhiKMQJBWwodW4FO" Bounds="827,557">
+                    <p:ValueBoxSettings />
+                  </Pad>
                 </Canvas>
                 <Patch Id="OFKH3wVHZ36PA2UlRTmJC6" Name="Create" ParticipatingElements="RdgXKDdnX4qM7SnbQnMOjg">
                   <Pin Id="SF0E3Gkq7WVOd9RXSGOQO3" Name="Properties" Kind="InputPin" />
@@ -1576,7 +1578,6 @@
                   <Pin Id="CDmPR5Pst7ZPJQMzjlh4DN" MergeId="145631" Name="KeyboardState" Kind="InputPin" />
                 </Patch>
                 <Link Id="H8ftCzCz7NGMfqccVuUFyj" Ids="LmpDiJtQ1eANxbkJVwoSPI,Q01nfPYCvPfPY2tugTj8Dc" IsHidden="true" />
-                <Link Id="Cys2vgfrXfROR7EcXSqfgS" Ids="CDmPR5Pst7ZPJQMzjlh4DN,RIfkH13QPg0NO36o8pZemA" IsHidden="true" />
                 <Link Id="CVjFYcWZw9nLYL6nj48ZbH" Ids="V4nTaygOvRaM97As4sGXv5,Gg5czGma29WMSd06KX72QY" IsHidden="true" />
                 <Link Id="MvpQhbg8ZUOP1FPjP5tfPy" Ids="CDmPR5Pst7ZPJQMzjlh4DN,UV07Pzq3wTrPZbH8jZem6n" IsHidden="true" />
                 <Link Id="Uli1dyq0g25OVBtHNtbKk8" Ids="Q01nfPYCvPfPY2tugTj8Dc,Q2HgrXF6gvLObiz44GbYbw" />
@@ -1585,10 +1586,11 @@
                 <Link Id="VmrlqniTY2kOU7YiIPhHAB" Ids="VSar1pQr7IlOI57iwEpjuN,Gkno7NBHCmMLB5DBvWgBBI" />
                 <Link Id="JJssxHgaTzQMOQ3cPfDU9C" Ids="AP194zvqkg0Ovlhkr3OWSn,NzrXEm2XVjSPfpu8W8R35y" />
                 <Link Id="N1Z8zfGQipQNr2Q8o1EK3A" Ids="AGZWuXUnON6MreCepSaME4,Dz8H4geHTwxNsqtYlYMNXa" />
-                <Link Id="TYNpRI1HgUSLSrcuGxDd9t" Ids="M2gAsV8stT7MBI3RLjNg9u,FYgkm3EUgznP5OHAqfw9lj" />
                 <Link Id="H1aM9EvTbTlP864ir4fpRH" Ids="CgHGnnO6SlhNoWWvcXoslc,Gw5pytjn0puMgZUd7U5Vji" />
                 <Link Id="TiIrk0tWJIQN5sWKZUYmfT" Ids="AW5R1jSyzvlQAKseILHdRU,PpRQomR8CspOYrGnEYZmdF" />
                 <Link Id="Sgs5GEXE6rjOjc2YI9lrYg" Ids="Sp3kHJBjSSJMaYglDwK4jy,Gm3BFNB119hNbrkOEkgQVq" />
+                <Link Id="A72xi36OR4pLwoncYfe2qO" Ids="STDQDJfemU7L6tdkyBdQpl,Dg9PWPzYNGXOJRS1XxePdT" />
+                <Link Id="Hm5Ne2uKTI5PrEnassNHgm" Ids="M2gAsV8stT7MBI3RLjNg9u,FYgkm3EUgznP5OHAqfw9lj" />
               </Patch>
             </Node>
           </Canvas>

--- a/vl/UIElements.vl
+++ b/vl/UIElements.vl
@@ -1403,6 +1403,33 @@
             <ControlPoint Id="Hp0Q9QCbih0Ow7AqMUwX2v" Bounds="519,242" />
             <ControlPoint Id="Jxs60EUjnxsN6y5bjggzau" Bounds="382,242" />
             <ControlPoint Id="T9PyIJfsl65LMZ8wbFjNxl" Bounds="485,537" />
+            <!--
+
+    ************************ ResetingSliderState ************************
+
+-->
+            <Node Name="ResetingSliderState" Bounds="913,513" Id="MWvv8fytBURMkhbIli9NjR">
+              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin">
+                <Choice Kind="ClassDefinition" Name="Class" />
+              </p:NodeReference>
+              <p:Interfaces>
+                <TypeReference LastCategoryFullName="VL.UIElements" LastSymbolSource="UIElements.vl">
+                  <Choice Kind="InterfaceTypeFlag" Name="IInteractionState" />
+                </TypeReference>
+              </p:Interfaces>
+              <Patch Id="V4MV8PjEz5DL8aBPw33ecm">
+                <Canvas Id="AHjLRCZ2xyAQW5Mer76jV8" CanvasType="Group" />
+                <Patch Id="OFKH3wVHZ36PA2UlRTmJC6" Name="Create" />
+                <!--
+
+    ************************  ************************
+
+-->
+                <ProcessDefinition Id="EgM1w94qlK3OFjMjGGNjxW" IsHidden="true">
+                  <Fragment Id="Jc9QEDld4eUMpXGjTCTxlj" Patch="OFKH3wVHZ36PA2UlRTmJC6" Enabled="true" />
+                </ProcessDefinition>
+              </Patch>
+            </Node>
           </Canvas>
           <Patch Id="PWEg4fI45OdNFJ5F8Cr3pC" Name="Create" />
           <Patch Id="UvSy1dW3I5ROVjXIxSOWMm" Name="Update" ManuallySortedPins="true">

--- a/vl/UIElements.vl
+++ b/vl/UIElements.vl
@@ -173,7 +173,7 @@
                     <Pin Id="K1fpqbZHMAlO4RdmVqABWM" Name="Point" Kind="InputPin" />
                     <Pin Id="CM2IU6RAhxYOO9kp02vFUs" Name="Result" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="412,534,488,285" Id="S2UhDJ5sDxPNPpDrLFSxs6">
+                  <Node Bounds="400,534,803,279" Id="S2UhDJ5sDxPNPpDrLFSxs6">
                     <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
@@ -270,6 +270,30 @@
                         <Pin Id="D3kMh9jOo63MeVQOmCTx7E" Name="Go" Kind="InputPin" />
                         <Pin Id="D81jcBrzJfnMX4ohHHAXzT" Name="State Reference" Kind="InputPin" />
                       </Node>
+                      <Node Bounds="1058,694,133,99" Id="R8cr0o3mmIFMCn8brP5tp8">
+                        <p:NodeReference LastCategoryFullName="VL.UIElements.Utils" LastSymbolSource="UIElements.vl">
+                          <Choice Kind="OperationCallFlag" Name="GoToState" />
+                          <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                        </p:NodeReference>
+                        <Pin Id="UINJrGIumlxOOO07JIWhF8" Name="Go" Kind="InputPin" />
+                        <Pin Id="MqQ4fOeveq5L7fCMEQkmsr" Name="State Reference" Kind="InputPin" />
+                        <Patch Id="QcrRsYreFk5LFKZBjMvwqs" Name="State Create" ManuallySortedPins="true">
+                          <Pin Id="CZ7izgkdS1LMlXgc0RMRlA" Name="Arg" Kind="InputPin" />
+                          <Pin Id="LPNxRUERhTrLa6MfPzO0P7" Name="Result" Kind="OutputPin" />
+                          <ControlPoint Id="RVlXC3fX852NEaaIkiVaGw" Bounds="1151,707" />
+                          <ControlPoint Id="K7r0Bibj1HiMjZAt6QuKHT" Bounds="1072,786" />
+                          <Node Bounds="1070,733,84,26" Id="RN9AjB80a6PL5OdKQk6TrM">
+                            <p:NodeReference LastCategoryFullName="VL.UIElements.SliderEditor.ResetingSliderState" LastSymbolSource="UIElements.vl">
+                              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                              <CategoryReference Kind="ClassType" Name="ResetingSliderState" />
+                              <Choice Kind="OperationCallFlag" Name="Create" />
+                            </p:NodeReference>
+                            <Pin Id="OUY0DbY4EATLti0X9eApkS" Name="Properties" Kind="InputPin" />
+                            <Pin Id="M77zxR4IlDeNZtBvvKatst" Name="State Reference" Kind="InputPin" />
+                            <Pin Id="HPonCO6ihcrM0qYL6VM9BX" Name="Output" Kind="StateOutputPin" />
+                          </Node>
+                        </Patch>
+                      </Node>
                     </Patch>
                   </Node>
                   <Node Bounds="791,477,52,19" Id="RQ815o3PFObOsmZfdzV5wG">
@@ -291,7 +315,7 @@
                     <Pin Id="LQhRkYGAuHCQNW3iSXKuae" Name="Input 3" Kind="InputPin" />
                     <Pin Id="M4SITeVNe1QLw4ybLihM8z" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <Pad Id="MoYibxj6tnpLwx3TYyWROw" SlotId="Erlm2WKXchyNYmvUkBsZRC" Bounds="991,554">
+                  <Pad Id="MoYibxj6tnpLwx3TYyWROw" SlotId="Erlm2WKXchyNYmvUkBsZRC" Bounds="841,616">
                     <p:ValueBoxSettings />
                   </Pad>
                   <Node Bounds="770,342,106,26" Id="EZaKbfgSK03QNbR85knGCe">
@@ -322,12 +346,12 @@
                   <Pad Id="TH3IhW60CoJN2qPHq0kOmQ" SlotId="Erlm2WKXchyNYmvUkBsZRC" Bounds="284,256">
                     <p:ValueBoxSettings />
                   </Pad>
-                  <Pad Id="PRc5GUd7gqhM9pq4MJd0gV" SlotId="GOM1Uj4KKYCOjV2AwzZFI9" Bounds="1021,631" />
+                  <Pad Id="PRc5GUd7gqhM9pq4MJd0gV" SlotId="GOM1Uj4KKYCOjV2AwzZFI9" Bounds="920,649" />
                   <Pad Id="P30sbi0f2jyOgla0zt3aoc" SlotId="GOM1Uj4KKYCOjV2AwzZFI9" Bounds="325,150" />
                   <Pad Id="HwhnwvDQ8IVNbqzu7LzPHV" SlotId="Erlm2WKXchyNYmvUkBsZRC" Bounds="357,648">
                     <p:ValueBoxSettings />
                   </Pad>
-                  <Pad Id="MOGT00pThHVLH0cpOFqDV7" SlotId="GOM1Uj4KKYCOjV2AwzZFI9" Bounds="365,611" />
+                  <Pad Id="MOGT00pThHVLH0cpOFqDV7" SlotId="GOM1Uj4KKYCOjV2AwzZFI9" Bounds="346,620" />
                   <Node Bounds="287,527,99,26" Id="NQERtTdJixAPViU7COPPzS">
                     <p:NodeReference LastCategoryFullName="VL.UIElements.SliderProperties" LastSymbolSource="UIElements.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -358,6 +382,17 @@
                     <Pin Id="KIR8xkPHFj6N3lE8EmhzIk" Name="Middle Down" Kind="OutputPin" />
                     <Pin Id="MsOD5NOxa3RLmrHnZBovot" Name="Middle Up" Kind="OutputPin" />
                   </Node>
+                  <Node Bounds="1057,492,37,19" Id="Sl3DqCmqeQYQc3y2KOePOR">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="AND" />
+                    </p:NodeReference>
+                    <Pin Id="SSKTqoubhf4LKVbSy8Suez" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="KuoDoSagMZxPEoNNlwJIjA" Name="Input 2" Kind="InputPin" />
+                    <Pin Id="KxW8qd2dxl4MRMBoO5jb7j" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Pad Id="LdDxo3VYtWVMfaXif0hWog" SlotId="Erlm2WKXchyNYmvUkBsZRC" Bounds="1262,563" />
+                  <Pad Id="GK0koBWqunsPUfn1GBhkmN" SlotId="GOM1Uj4KKYCOjV2AwzZFI9" Bounds="1299,630" />
                 </Canvas>
                 <Patch Id="TSSgQ3SVs1uNYyKtGXfN3J" Name="Create">
                   <Pin Id="T4d0ia6ngAeOiQ3tFwjzEu" Name="State Reference" Kind="InputPin" />
@@ -434,6 +469,15 @@
                 <Link Id="HjZ40PbOcSYMtmz2VDyYz6" Ids="SMIkaxmzingMLbNHYRlrog,LQhRkYGAuHCQNW3iSXKuae" />
                 <Link Id="SJOwUQx2mNrMJ9BI1Jbfb6" Ids="FXGqbRsrujPLO4udrtLsCh,GKLsYR8zVtCLM2WL4UsLJj" />
                 <Link Id="PikG4YJovueNEMhyWQ3Rfd" Ids="CM2IU6RAhxYOO9kp02vFUs,F5wELj0oeafLq8o9fl4q2B" />
+                <Link Id="N7os5DqU08XLvWLM6Va801" Ids="CZ7izgkdS1LMlXgc0RMRlA,RVlXC3fX852NEaaIkiVaGw" IsHidden="true" />
+                <Link Id="OnYpjnqeawqLAzEc3HUk5G" Ids="K7r0Bibj1HiMjZAt6QuKHT,LPNxRUERhTrLa6MfPzO0P7" IsHidden="true" />
+                <Link Id="FmHZTdtLwekO83J4tKnq42" Ids="FBoirimTuZ9OLSJE70EemN,KuoDoSagMZxPEoNNlwJIjA" />
+                <Link Id="OU4PYVZ6kIkOxsCW2JoBd8" Ids="CM2IU6RAhxYOO9kp02vFUs,SSKTqoubhf4LKVbSy8Suez" />
+                <Link Id="BXeZaBzLCrbN8bveHDCpJ9" Ids="KxW8qd2dxl4MRMBoO5jb7j,UINJrGIumlxOOO07JIWhF8" />
+                <Link Id="CVRAiHslk79NR7aXz1v3m5" Ids="HPonCO6ihcrM0qYL6VM9BX,K7r0Bibj1HiMjZAt6QuKHT" />
+                <Link Id="SI9h9CqCy7fMoDg2DqJpZx" Ids="RVlXC3fX852NEaaIkiVaGw,M77zxR4IlDeNZtBvvKatst" />
+                <Link Id="GtENyupxq7OLRnqAUPF6p9" Ids="LdDxo3VYtWVMfaXif0hWog,OUY0DbY4EATLti0X9eApkS" />
+                <Link Id="IJ3tXx3CH0RPcI5X3fWPgl" Ids="GK0koBWqunsPUfn1GBhkmN,MqQ4fOeveq5L7fCMEQkmsr" />
               </Patch>
             </Node>
             <!--
@@ -662,6 +706,7 @@
                     <Pin Id="DDlfgGsLcHALzbcur49pjI" Name="Value Range" Kind="OutputPin" />
                     <Pin Id="Hj8dEAX4mvePfQvQQxwHbQ" Name="Do Clamp" Kind="OutputPin" />
                     <Pin Id="CvVDair0chMNkirLbYJoJ4" Name="Is Cyclic" Kind="OutputPin" />
+                    <Pin Id="Kk61k7v2bjJLPGpXeqBjM1" Name="Default Value" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="483,184,38,26" Id="AxGHAMpSIZVLehtYQzNCmj">
                     <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastSymbolSource="CoreLibBasics.vl">
@@ -1429,6 +1474,44 @@
                   <ControlPoint Id="Q01nfPYCvPfPY2tugTj8Dc" Bounds="662,472" />
                   <ControlPoint Id="RIfkH13QPg0NO36o8pZemA" Bounds="858,472" />
                   <ControlPoint Id="UV07Pzq3wTrPZbH8jZem6n" Bounds="1028,472" />
+                  <Node Bounds="660,514,106,26" Id="N4FIEu02GJzNwwmEmU5UhA">
+                    <p:NodeReference LastCategoryFullName="VL.UIElements.Utils.MouseState" LastSymbolSource="UIElements.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="GetMouseEventKind" />
+                    </p:NodeReference>
+                    <Pin Id="Q2HgrXF6gvLObiz44GbYbw" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="Ml35Fthx1TwOr8RvOot4PW" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="UdPyqD98JMuLYHwfqf0IqA" Name="Mouse Move" Kind="OutputPin" />
+                    <Pin Id="TdeZiz7swz8LU3e85XP9JT" Name="Mouse Down" Kind="OutputPin" />
+                    <Pin Id="VSar1pQr7IlOI57iwEpjuN" Name="Mouse Up" Kind="OutputPin" />
+                    <Pin Id="TUKUiGJZhFAPfFyjBLPdvc" Name="Double Click" Kind="OutputPin" />
+                    <Pin Id="GQJZShLpQkJP6wGXHbhE9r" Name="IsLost" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="721,610,109,84" Id="FtqKNo5Fuo6PpUxbBvF3VV">
+                    <p:NodeReference LastCategoryFullName="VL.UIElements.Utils" LastSymbolSource="UIElements.vl">
+                      <Choice Kind="OperationCallFlag" Name="GoToState" />
+                      <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                    </p:NodeReference>
+                    <Pin Id="Gkno7NBHCmMLB5DBvWgBBI" Name="Go" Kind="InputPin" />
+                    <Pin Id="Dg9PWPzYNGXOJRS1XxePdT" Name="State Reference" Kind="InputPin" />
+                    <Patch Id="OhyDjYDUgMRNQ2d4wVZIiM" Name="State Create" ManuallySortedPins="true">
+                      <Pin Id="MMdsJcHtRd3PyveHwOVl2e" Name="Arg" Kind="InputPin" />
+                      <Pin Id="MHXbdI3PDvlOgMF7it6PZG" Name="Result" Kind="OutputPin" />
+                      <ControlPoint Id="AP194zvqkg0Ovlhkr3OWSn" Bounds="735,618" />
+                      <ControlPoint Id="Dz8H4geHTwxNsqtYlYMNXa" Bounds="735,687" />
+                      <Node Bounds="733,640,85,26" Id="GU2bVFdpFOtNU98OIXXuLR">
+                        <p:NodeReference LastCategoryFullName="Main.Slider.IdleSliderState" LastSymbolSource="state pattern prototype 11.vl">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <Choice Kind="OperationCallFlag" Name="Create" />
+                          <CategoryReference Kind="Category" Name="IdleSliderState" NeedsToBeDirectParent="true" />
+                        </p:NodeReference>
+                        <Pin Id="NzrXEm2XVjSPfpu8W8R35y" Name="State Reference" Kind="InputPin" />
+                        <Pin Id="FYgkm3EUgznP5OHAqfw9lj" Name="Properties" Kind="InputPin" />
+                        <Pin Id="AGZWuXUnON6MreCepSaME4" Name="Output" Kind="StateOutputPin" />
+                      </Node>
+                    </Patch>
+                  </Node>
+                  <Pad Id="M2gAsV8stT7MBI3RLjNg9u" SlotId="RzaKFt2UDs5MyNLtUTnjJh" Bounds="815,579" />
                 </Canvas>
                 <Patch Id="OFKH3wVHZ36PA2UlRTmJC6" Name="Create" ParticipatingElements="RdgXKDdnX4qM7SnbQnMOjg">
                   <Pin Id="SF0E3Gkq7WVOd9RXSGOQO3" Name="Properties" Kind="InputPin" />
@@ -1452,7 +1535,12 @@
                 <Link Id="RdgXKDdnX4qM7SnbQnMOjg" Ids="Sc1t3np8ve9Nnkgm1rFgx0,Pn4o6hkuXC8Ms8sNj7Ak9a" />
                 <Slot Id="IEKTIpvhiKMQJBWwodW4FO" Name="Reference">
                   <p:TypeAnnotation>
-                    <Choice Kind="TypeFlag" Name="IInteractionState" />
+                    <Choice Kind="TypeFlag" Name="Reference" />
+                    <p:TypeArguments>
+                      <TypeReference>
+                        <Choice Kind="TypeFlag" Name="IInteractionState" />
+                      </TypeReference>
+                    </p:TypeArguments>
                   </p:TypeAnnotation>
                 </Slot>
                 <Link Id="O1STntPYclVLPeDMWLU1Ng" Ids="F8HYkchzbL3PFWsRNWK7qI,HHN7ESzrLQiLxVhTbOu0b1" />
@@ -1466,6 +1554,13 @@
                 <Link Id="Cys2vgfrXfROR7EcXSqfgS" Ids="CDmPR5Pst7ZPJQMzjlh4DN,RIfkH13QPg0NO36o8pZemA" IsHidden="true" />
                 <Link Id="CVjFYcWZw9nLYL6nj48ZbH" Ids="V4nTaygOvRaM97As4sGXv5,Gg5czGma29WMSd06KX72QY" IsHidden="true" />
                 <Link Id="MvpQhbg8ZUOP1FPjP5tfPy" Ids="CDmPR5Pst7ZPJQMzjlh4DN,UV07Pzq3wTrPZbH8jZem6n" IsHidden="true" />
+                <Link Id="Uli1dyq0g25OVBtHNtbKk8" Ids="Q01nfPYCvPfPY2tugTj8Dc,Q2HgrXF6gvLObiz44GbYbw" />
+                <Link Id="AlQd3hqrOPCLZPyYAwUrCF" Ids="MMdsJcHtRd3PyveHwOVl2e,AP194zvqkg0Ovlhkr3OWSn" IsHidden="true" />
+                <Link Id="QZ7UDUjwjLiL2ZqLfXuaH3" Ids="Dz8H4geHTwxNsqtYlYMNXa,MHXbdI3PDvlOgMF7it6PZG" IsHidden="true" />
+                <Link Id="VmrlqniTY2kOU7YiIPhHAB" Ids="VSar1pQr7IlOI57iwEpjuN,Gkno7NBHCmMLB5DBvWgBBI" />
+                <Link Id="JJssxHgaTzQMOQ3cPfDU9C" Ids="AP194zvqkg0Ovlhkr3OWSn,NzrXEm2XVjSPfpu8W8R35y" />
+                <Link Id="N1Z8zfGQipQNr2Q8o1EK3A" Ids="AGZWuXUnON6MreCepSaME4,Dz8H4geHTwxNsqtYlYMNXa" />
+                <Link Id="TYNpRI1HgUSLSrcuGxDd9t" Ids="M2gAsV8stT7MBI3RLjNg9u,FYgkm3EUgznP5OHAqfw9lj" />
               </Patch>
             </Node>
           </Canvas>
@@ -1940,6 +2035,7 @@
               <Pin Id="OndTVsGCv9xPD6xJA1LeZ3" Name="Value Range" Kind="OutputPin" />
               <Pin Id="T3VnQFU7DQRNl40X1pDBsH" Name="Do Clamp" Kind="OutputPin" />
               <Pin Id="VbPIl6BsSqrPI6RhJGMGga" Name="Is Cyclic" Kind="OutputPin" />
+              <Pin Id="KPfic5xWli5PBTVKieH9Ta" Name="Default Value" Kind="OutputPin" />
             </Node>
             <Node Bounds="-277,48,237,278" Id="AhO38AkMLf6PEuifYhdqn2">
               <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
@@ -2180,6 +2276,7 @@
               <Pin Id="UgcFoWgykGUNwLVx7404k4" Name="Value Range" Kind="InputPin" />
               <Pin Id="Oi8RYCnPKs7Nrn2p8sacK7" Name="Do Clamp" Kind="InputPin" />
               <Pin Id="RhurdsQcXraOgZzH4OnniT" Name="Is Cyclic" Kind="InputPin" />
+              <Pin Id="SW79WGIObz0NnEO54XR2pY" Name="Default Value" Kind="InputPin" />
               <Pin Id="A9KYgfN48htPZtm3xuKh4I" Name="Output" Kind="OutputPin" />
             </Node>
             <ControlPoint Id="KRgycylSolqOcNnMkby2ik" Bounds="281,91" />
@@ -2344,10 +2441,10 @@
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="Ak4zckUTotXMG4VcSc2bUh" SlotId="QcajiV4SY8ULQkAOxgsdjD" Bounds="689,182">
+            <Pad Id="Ak4zckUTotXMG4VcSc2bUh" SlotId="QcajiV4SY8ULQkAOxgsdjD" Bounds="689,167">
               <p:ValueBoxSettings />
             </Pad>
-            <Pad Id="GzNehXBogvvOXgRKGDjyKm" SlotId="F0AtD0qNKRRMqYzvpfUlbI" Bounds="775,183">
+            <Pad Id="GzNehXBogvvOXgRKGDjyKm" SlotId="F0AtD0qNKRRMqYzvpfUlbI" Bounds="787,167">
               <p:ValueBoxSettings />
             </Pad>
             <Pad Id="JpPVpWDu5sAQMxDn6ZGyiK" SlotId="QcajiV4SY8ULQkAOxgsdjD" Bounds="479,501">
@@ -2398,11 +2495,11 @@
               <p:ValueBoxSettings />
             </Pad>
             <ControlPoint Id="FGWsKA0w3l9LOr5ZTrIW01" Bounds="460,137" />
-            <ControlPoint Id="CQpfpNyhBAJPmPkGBxEYRl" Bounds="687,132" />
-            <ControlPoint Id="OwCKArtwJqGLxSwEdtBUMa" Bounds="771,132" />
+            <ControlPoint Id="CQpfpNyhBAJPmPkGBxEYRl" Bounds="689,134" />
+            <ControlPoint Id="OwCKArtwJqGLxSwEdtBUMa" Bounds="787,134" />
             <ControlPoint Id="VMYd8lRVyVkMhEwX4aYHDX" Bounds="439,254" />
-            <ControlPoint Id="CZJjEC9qv03N9xACV0QtGB" Bounds="689,256" />
-            <ControlPoint Id="MWAN6qXre5vOQi0n9lzBb9" Bounds="775,256" />
+            <ControlPoint Id="CZJjEC9qv03N9xACV0QtGB" Bounds="689,207" />
+            <ControlPoint Id="MWAN6qXre5vOQi0n9lzBb9" Bounds="787,207" />
             <ControlPoint Id="EbpG90FgCmBM9IrHQFxL0t" Bounds="465,207" />
             <Pad Id="VDPYXkSUu5DP8igfYqxOpu" SlotId="K2JyvJEdKdoP4MZPgsLSaA" Bounds="319,595">
               <p:ValueBoxSettings />
@@ -2434,6 +2531,11 @@
               <Pin Id="DambgeUlArDM162Eknd3VE" Name="From" Kind="OutputPin" />
               <Pin Id="ImCjLCf04dKMC8R80Emmf2" Name="To" Kind="OutputPin" />
             </Node>
+            <Pad Id="ExbYher9fOmMKyI9JO3xl6" SlotId="Vgz5YcZuY0zPaEz4DEYF08" Bounds="885,167">
+              <p:ValueBoxSettings />
+            </Pad>
+            <ControlPoint Id="JspjRKlQxqMNvui4uw1oJc" Bounds="885,134" />
+            <ControlPoint Id="J1M5VP0BW5OPckleCKVdnw" Bounds="886,207" />
           </Canvas>
           <Patch Id="QOKaMgl4n2IMfykoSF8rga" Name="Create" ParticipatingElements="J2vVexp60w4MxaGpMiFJYX,SAPAC1ap72VO9AVRlE0axI" />
           <ProcessDefinition Id="KuydFQYIGRTMyhfOCtDpfe" HasStateOut="true">
@@ -2626,6 +2728,7 @@
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="VfJtUOTRSjgP8QQkf3mRYb" Name="Is Cyclic" Kind="InputPin" />
+            <Pin Id="O17Ev77VpZsOuJAXaSePXO" Name="Default Value" Kind="InputPin" />
           </Patch>
           <Link Id="VS8SnMgbryaMU9BjcXx2D0" Ids="UsWRJXrarsuN7oe4xySLCQ,VMYd8lRVyVkMhEwX4aYHDX" />
           <Link Id="EF9W9t40TjJPW4wZnbIm28" Ids="VMYd8lRVyVkMhEwX4aYHDX,NcmHOcTrwuKOwXahWwtgLh" IsHidden="true" />
@@ -2637,6 +2740,7 @@
             <Pin Id="NcmHOcTrwuKOwXahWwtgLh" Name="Value Range" Kind="OutputPin" />
             <Pin Id="JvgsUREmrTON4e3rqy9QnI" Name="Do Clamp" Kind="OutputPin" />
             <Pin Id="B0cRBJ1qbRZQVRdcXdFXwJ" Name="Is Cyclic" Kind="OutputPin" />
+            <Pin Id="VzwZ0tZecNxNR3ktSXkvHu" Name="Default Value" Kind="OutputPin" />
           </Patch>
           <Link Id="MeqgV2aUiujMO4y5809rbV" Ids="UsWRJXrarsuN7oe4xySLCQ,EbpG90FgCmBM9IrHQFxL0t" />
           <Link Id="FFYBRoymrtMQOMs2vq1nUn" Ids="EbpG90FgCmBM9IrHQFxL0t,OPTOZ3keo1dOU7DaZKqH03" IsHidden="true" />
@@ -2652,6 +2756,15 @@
           <Link Id="Q8OQ2PLUvs6NSLe8NPtuI4" Ids="NBLBNlQoXIhMLW4VQtkzZZ,G5UHGlIbGqAPHG6ON6Y7UN" />
           <Link Id="CBzoceEpLDjP2rBN3teQ6E" Ids="DambgeUlArDM162Eknd3VE,FJ51CX0EKDrMSkC8la58E3" />
           <Link Id="DYw2CkAa8deLlrR0lLtwks" Ids="ImCjLCf04dKMC8R80Emmf2,D8Je6VDBRlANVf0cdK0CWh" />
+          <Slot Id="Vgz5YcZuY0zPaEz4DEYF08" Name="Default Value">
+            <p:TypeAnnotation>
+              <Choice Kind="TypeFlag" Name="Float32" />
+            </p:TypeAnnotation>
+          </Slot>
+          <Link Id="Eb8T3IG3TldQMWdKpRXs5J" Ids="JspjRKlQxqMNvui4uw1oJc,ExbYher9fOmMKyI9JO3xl6" />
+          <Link Id="Nv1IRM9yxOcM1rbFVVlRDz" Ids="O17Ev77VpZsOuJAXaSePXO,JspjRKlQxqMNvui4uw1oJc" IsHidden="true" />
+          <Link Id="UabHhO0V4HjQRtxlseVe15" Ids="ExbYher9fOmMKyI9JO3xl6,J1M5VP0BW5OPckleCKVdnw" />
+          <Link Id="VjodjsLLdwiOevpWhwgeRl" Ids="J1M5VP0BW5OPckleCKVdnw,VzwZ0tZecNxNR3ktSXkvHu" IsHidden="true" />
         </Patch>
       </Node>
       <!--

--- a/vl/UIElements.vl
+++ b/vl/UIElements.vl
@@ -1512,6 +1512,31 @@
                     </Patch>
                   </Node>
                   <Pad Id="M2gAsV8stT7MBI3RLjNg9u" SlotId="RzaKFt2UDs5MyNLtUTnjJh" Bounds="815,579" />
+                  <Node Bounds="465,546" Id="Oezl0wq5bGTMAR4OrBcfZc">
+                    <p:NodeReference LastCategoryFullName="VL.UIElements.SliderProperties" LastSymbolSource="UIElements.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="SliderProperties" />
+                      <Choice Kind="OperationCallFlag" Name="GetValueProperties" />
+                    </p:NodeReference>
+                    <Pin Id="Gw5pytjn0puMgZUd7U5Vji" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="AW5R1jSyzvlQAKseILHdRU" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="VXZhJqJDUYoOVQv7MWAsYV" Name="Value Range" Kind="OutputPin" />
+                    <Pin Id="BRRY2Atjk3uLMpl4IgvPPU" Name="Do Clamp" Kind="OutputPin" />
+                    <Pin Id="OjaNW79ZGnROg1klReKS5M" Name="Is Cyclic" Kind="OutputPin" />
+                    <Pin Id="Sp3kHJBjSSJMaYglDwK4jy" Name="Default Value" Kind="OutputPin" />
+                  </Node>
+                  <Pad Id="CgHGnnO6SlhNoWWvcXoslc" SlotId="RzaKFt2UDs5MyNLtUTnjJh" Bounds="467,479" />
+                  <Node Bounds="465,624,72,26" Id="FGyjlcZlzHfPRqXgIpSc2H">
+                    <p:NodeReference LastCategoryFullName="VL.UIElements.SliderProperties" LastSymbolSource="UIElements.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="SetValue" />
+                      <CategoryReference Kind="ClassType" Name="SliderProperties" NeedsToBeDirectParent="true" />
+                    </p:NodeReference>
+                    <Pin Id="PpRQomR8CspOYrGnEYZmdF" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="Iw0nV6myUbZLwvKeNivdnU" Name="Push To Observable" Kind="InputPin" />
+                    <Pin Id="Gm3BFNB119hNbrkOEkgQVq" Name="Value" Kind="InputPin" />
+                    <Pin Id="BQz26ttKiJ3Ox9fp78UQGh" Name="Output" Kind="StateOutputPin" />
+                  </Node>
                 </Canvas>
                 <Patch Id="OFKH3wVHZ36PA2UlRTmJC6" Name="Create" ParticipatingElements="RdgXKDdnX4qM7SnbQnMOjg">
                   <Pin Id="SF0E3Gkq7WVOd9RXSGOQO3" Name="Properties" Kind="InputPin" />
@@ -1545,7 +1570,7 @@
                 </Slot>
                 <Link Id="O1STntPYclVLPeDMWLU1Ng" Ids="F8HYkchzbL3PFWsRNWK7qI,HHN7ESzrLQiLxVhTbOu0b1" />
                 <Link Id="LCcdtHoYO7oQH9VbuDTdNn" Ids="DIiZApTAXNxNZgBrYsGzF4,F8HYkchzbL3PFWsRNWK7qI" IsHidden="true" />
-                <Patch Id="VK7pGqAiHi6PJKSyc14XHB" Name="ProcessNotification">
+                <Patch Id="VK7pGqAiHi6PJKSyc14XHB" Name="ProcessNotification" ParticipatingElements="Oezl0wq5bGTMAR4OrBcfZc">
                   <Pin Id="V4nTaygOvRaM97As4sGXv5" MergeId="145629" Name="Notification" Kind="InputPin" />
                   <Pin Id="LmpDiJtQ1eANxbkJVwoSPI" MergeId="145630" Name="MouseState" Kind="InputPin" />
                   <Pin Id="CDmPR5Pst7ZPJQMzjlh4DN" MergeId="145631" Name="KeyboardState" Kind="InputPin" />
@@ -1561,6 +1586,9 @@
                 <Link Id="JJssxHgaTzQMOQ3cPfDU9C" Ids="AP194zvqkg0Ovlhkr3OWSn,NzrXEm2XVjSPfpu8W8R35y" />
                 <Link Id="N1Z8zfGQipQNr2Q8o1EK3A" Ids="AGZWuXUnON6MreCepSaME4,Dz8H4geHTwxNsqtYlYMNXa" />
                 <Link Id="TYNpRI1HgUSLSrcuGxDd9t" Ids="M2gAsV8stT7MBI3RLjNg9u,FYgkm3EUgznP5OHAqfw9lj" />
+                <Link Id="H1aM9EvTbTlP864ir4fpRH" Ids="CgHGnnO6SlhNoWWvcXoslc,Gw5pytjn0puMgZUd7U5Vji" />
+                <Link Id="TiIrk0tWJIQN5sWKZUYmfT" Ids="AW5R1jSyzvlQAKseILHdRU,PpRQomR8CspOYrGnEYZmdF" />
+                <Link Id="Sgs5GEXE6rjOjc2YI9lrYg" Ids="Sp3kHJBjSSJMaYglDwK4jy,Gm3BFNB119hNbrkOEkgQVq" />
               </Patch>
             </Node>
           </Canvas>
@@ -2240,9 +2268,9 @@
             <ControlPoint Id="KLZKQ1rmiHxLui5LtmsFKC" Bounds="257,579" />
             <ControlPoint Id="IYFG9TIHDpiNW8KoXpUPrV" Bounds="541,471" />
             <ControlPoint Id="PfKF0RE1lTaMUB7C2Q5h3D" Bounds="446,471" />
-            <ControlPoint Id="FI7Rj4qKOOiMbL08ExfK4o" Bounds="389,286" />
-            <ControlPoint Id="ADqodylj5lxOT0rrdzVj1Z" Bounds="416,308" />
-            <Node Bounds="362,239,44,19" Id="BcE8mmWR3LtN3ayIcykJxz">
+            <ControlPoint Id="FI7Rj4qKOOiMbL08ExfK4o" Bounds="370,269" />
+            <ControlPoint Id="ADqodylj5lxOT0rrdzVj1Z" Bounds="394,289" />
+            <Node Bounds="347,234,44,19" Id="BcE8mmWR3LtN3ayIcykJxz">
               <p:NodeReference LastCategoryFullName="Math.Ranges.Range" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Range (Join)" />
@@ -2251,11 +2279,11 @@
               <Pin Id="LsMy58PLH08MtrvZueJnz4" Name="To" Kind="InputPin" />
               <Pin Id="FbamPlqCw5DLnzs55cy2bs" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <ControlPoint Id="HZwE7L2OJX6OYsq2A5HySZ" Bounds="364,190" />
-            <ControlPoint Id="S75S4FWyS45O6Q4TZXytGq" Bounds="403,217" />
+            <ControlPoint Id="HZwE7L2OJX6OYsq2A5HySZ" Bounds="349,185" />
+            <ControlPoint Id="S75S4FWyS45O6Q4TZXytGq" Bounds="388,212" />
             <ControlPoint Id="CT3T5rJuMnoLJMGw9JPh49" Bounds="256,62" />
-            <ControlPoint Id="LOS4EPngLCTOABR2O5lnET" Bounds="309,116" />
-            <Node Bounds="335,143,57,19" Id="DCCHPzjKcpmLTOzCweeoFt">
+            <ControlPoint Id="LOS4EPngLCTOABR2O5lnET" Bounds="303,115" />
+            <Node Bounds="325,140,57,19" Id="DCCHPzjKcpmLTOzCweeoFt">
               <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Changed" />
@@ -2264,7 +2292,7 @@
               <Pin Id="CP9kMxIiGYNPpAhq9soPvW" Name="Result" Kind="OutputPin" />
               <Pin Id="M44dyFzTsCdPfQWXAWKYgc" Name="Unchanged" Kind="OutputPin" />
             </Node>
-            <Node Bounds="255,332,164,19" Id="UMsFaEH8GQ5PiyYltY6xaL">
+            <Node Bounds="255,347,164,19" Id="UMsFaEH8GQ5PiyYltY6xaL">
               <p:NodeReference LastCategoryFullName="VL.UIElements" LastSymbolSource="UIElements.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="SliderProperties" />
@@ -2281,6 +2309,7 @@
             </Node>
             <ControlPoint Id="KRgycylSolqOcNnMkby2ik" Bounds="281,91" />
             <ControlPoint Id="TgQF4DHwFdeP5s0g9L5IU5" Bounds="541,374" />
+            <ControlPoint Id="TgLdNwbeSvWOQN41vZBr2g" Bounds="416,314" />
           </Canvas>
           <Patch Id="SxixMf5MBB2M9nmZMLuT9x" Name="Create" />
           <ProcessDefinition Id="IMBfb0hFEOtPtkyseFMlXX">
@@ -2301,6 +2330,11 @@
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="L2z3X1y9XMyMz25RkKFfRn" Name="Is Cyclic" Kind="InputPin" Bounds="501,232" Visibility="Optional" />
+            <Pin Id="RPfakDC8RdjNzPeu0REhLm" Name="Default Value" Kind="InputPin" Bounds="441,317" DefaultValue="0.5" Visibility="Optional">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Float32" />
+              </p:TypeAnnotation>
+            </Pin>
             <Pin Id="JvtlBj5WbO4PUiOLcv33HI" Name="On Interaction" Kind="OutputPin" Bounds="770,497" />
             <Pin Id="AuJBCOxpMQpNPOqqUEH7Ub" Name="Reset Interaction" Kind="InputPin" Bounds="500,301" Visibility="Optional" />
             <Pin Id="DA1AE6QJ71VQGbZJdeOjLM" Name="Value" Kind="OutputPin" Bounds="849,388" />
@@ -2333,6 +2367,8 @@
           <Link Id="MaIHiNAeXKPNXSaBrNx8HP" Ids="AuJBCOxpMQpNPOqqUEH7Ub,TgQF4DHwFdeP5s0g9L5IU5" IsHidden="true" />
           <Link Id="ReBCCTcpB4hNwMNmCLmHSh" Ids="MiEwh8aQznjOC3YMi2fx3F,RWNoy9eOL49NowbiwldxZR" />
           <Link Id="PnEiEYEXNOlQW1PLrLSh0v" Ids="OejB753EcvFLrWFN7dae34,KW3LIa1i8gWP3pGXnUG981" />
+          <Link Id="KnipTkoHHp9LWqfW6FIypP" Ids="TgLdNwbeSvWOQN41vZBr2g,SW79WGIObz0NnEO54XR2pY" />
+          <Link Id="AvQNP4D75PqMqfmXn3A2qv" Ids="RPfakDC8RdjNzPeu0REhLm,TgLdNwbeSvWOQN41vZBr2g" IsHidden="true" />
         </Patch>
       </Node>
       <!--

--- a/vl/UIElements.vl
+++ b/vl/UIElements.vl
@@ -183,7 +183,7 @@
                     <Patch Id="Lcx6gmxtER3N8no8zKdmiS" ManuallySortedPins="true">
                       <Patch Id="ChhZXEs2gQdOttXposJgvR" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="DCdHtjZFjk0PpV197QBv9h" Name="Then" ManuallySortedPins="true" />
-                      <Node Bounds="435,559,228,240" Id="CgGuEyHqlgVOPJvlRhzKPe">
+                      <Node Bounds="423,559,240,206" Id="CgGuEyHqlgVOPJvlRhzKPe">
                         <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
@@ -210,7 +210,7 @@
                             <Pin Id="AEE6gFfn2BcM5Z6ZcSC6fy" Name="Middle Down" Kind="OutputPin" />
                             <Pin Id="OadvThTwsb3N4PgcExE6lS" Name="Middle Up" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="498,693,133,86" Id="JK1VtmroVrhNlO52MZ1Mm4">
+                          <Node Bounds="486,669,134,76" Id="JK1VtmroVrhNlO52MZ1Mm4">
                             <p:NodeReference LastCategoryFullName="VL.UIElements.Utils" LastSymbolSource="UIElements.vl">
                               <Choice Kind="OperationCallFlag" Name="GoToState" />
                               <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -218,9 +218,9 @@
                             <Patch Id="Cmp5wwsQMqmOxjX5lzEMx3" Name="State Create" ManuallySortedPins="true">
                               <Pin Id="Fbk4n6C6ZU7Lo54g92aOQm" Name="Arg" Kind="InputPin" />
                               <Pin Id="IkPO8aQHDHENCSN86hwZNI" Name="Result" Kind="OutputPin" />
-                              <ControlPoint Id="DwzHHVDyXXXOKAexhhpW3X" Bounds="591,701" />
-                              <ControlPoint Id="TwKJQhwtKI0MdinZpjoyBA" Bounds="513,772" />
-                              <Node Bounds="510,720,85,26" Id="RqVUaWONviXLSUeHTZYSjx">
+                              <ControlPoint Id="DwzHHVDyXXXOKAexhhpW3X" Bounds="580,677" />
+                              <ControlPoint Id="TwKJQhwtKI0MdinZpjoyBA" Bounds="500,738" />
+                              <Node Bounds="498,694,85,26" Id="RqVUaWONviXLSUeHTZYSjx">
                                 <p:NodeReference LastCategoryFullName="Main.Slider.TypingSliderState" LastSymbolSource="state pattern prototype 11.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="Create" />
@@ -272,7 +272,7 @@
                       </Node>
                     </Patch>
                   </Node>
-                  <Node Bounds="790,473,52,19" Id="RQ815o3PFObOsmZfdzV5wG">
+                  <Node Bounds="791,477,52,19" Id="RQ815o3PFObOsmZfdzV5wG">
                     <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="FlipFlop" />
@@ -281,19 +281,20 @@
                     <Pin Id="P7cmd4CoOtCNff3IT9NfJj" Name="Reset" Kind="ApplyPin" />
                     <Pin Id="PUtk3kSNtbOLCnFhVnHesx" Name="State" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="790,445,37,19" Id="BJH9NwUUxdcLhYDOMzsia9">
+                  <Node Bounds="791,449,45,19" Id="BJH9NwUUxdcLhYDOMzsia9">
                     <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="AND" />
                     </p:NodeReference>
                     <Pin Id="HqfNl2F8M8gNquh4Vch49C" Name="Input" Kind="StateInputPin" />
                     <Pin Id="J8tqYALsC5pLGmhxn6gD77" Name="Input 2" Kind="InputPin" />
+                    <Pin Id="LQhRkYGAuHCQNW3iSXKuae" Name="Input 3" Kind="InputPin" />
                     <Pin Id="M4SITeVNe1QLw4ybLihM8z" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Pad Id="MoYibxj6tnpLwx3TYyWROw" SlotId="Erlm2WKXchyNYmvUkBsZRC" Bounds="991,554">
                     <p:ValueBoxSettings />
                   </Pad>
-                  <Node Bounds="768,336,106,26" Id="EZaKbfgSK03QNbR85knGCe">
+                  <Node Bounds="770,342,106,26" Id="EZaKbfgSK03QNbR85knGCe">
                     <p:NodeReference LastCategoryFullName="VL.UIElements.Utils.MouseState" LastSymbolSource="UIElements.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetMouseEventKind" />
@@ -339,6 +340,23 @@
                     <Pin Id="Db6tuoMFOnKO0PTxv1Hvjg" Name="Is in Focus" Kind="InputPin" />
                     <Pin Id="TtzPJIlLGaoPlpodWm5wWq" Name="Is Text Preview" Kind="InputPin" />
                     <Pin Id="BrpiOxdHH6rLtNnEZebFBW" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="931,342,185,26" Id="M26Z20BHODFP90IGSAaCnx">
+                    <p:NodeReference LastCategoryFullName="VL.UIElements.Utils.MouseState" LastSymbolSource="UIElements.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="GetMouseButtons" />
+                    </p:NodeReference>
+                    <Pin Id="GKLsYR8zVtCLM2WL4UsLJj" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="Lu8b0up1zTzOtG1IW3EF1L" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="SMIkaxmzingMLbNHYRlrog" Name="Left Pressed" Kind="OutputPin" />
+                    <Pin Id="FBoirimTuZ9OLSJE70EemN" Name="Middle Pressed" Kind="OutputPin" />
+                    <Pin Id="HCVeazmYE7wQZmCwwHvJH2" Name="Right Pressed" Kind="OutputPin" />
+                    <Pin Id="GYfyDF5b3jUNHNeC7oqF1m" Name="Left Down" Kind="OutputPin" />
+                    <Pin Id="Udsl6ZxeZQGPg4fuuMpGG7" Name="Left Up" Kind="OutputPin" />
+                    <Pin Id="E9l2oze6ttBMloYMhB1UfH" Name="Right Down" Kind="OutputPin" />
+                    <Pin Id="BaD8KvQzckeOFmZMpsRQSa" Name="Right Up" Kind="OutputPin" />
+                    <Pin Id="KIR8xkPHFj6N3lE8EmhzIk" Name="Middle Down" Kind="OutputPin" />
+                    <Pin Id="MsOD5NOxa3RLmrHnZBovot" Name="Middle Up" Kind="OutputPin" />
                   </Node>
                 </Canvas>
                 <Patch Id="TSSgQ3SVs1uNYyKtGXfN3J" Name="Create">
@@ -410,10 +428,12 @@
                 <Link Id="B5g2Rzs1pbeLrPMyiD8RHA" Ids="Tbzq4u2Pwu2MLHMZETCM5E,MNV5yzfFvRNOabZ4WvX3UX" />
                 <Link Id="IXFfxhIlJuIL2OXCGX3GXo" Ids="FZuJAlxjWprMVNuqNAy6mr,GLPvY94RDN3Lfifzu1iDIb" IsHidden="true" />
                 <Link Id="EVdsCWsioRWMtKxMNabaWk" Ids="U6to8fjtJ2jLynJCpE0wMU,NPrJEtFS8TZLtyeWX5hV5f" IsHidden="true" />
-                <Link Id="QFlzJagAuANNP6b5utfs0e" Ids="CM2IU6RAhxYOO9kp02vFUs,F5wELj0oeafLq8o9fl4q2B" />
                 <Link Id="JQHMDBuHAczMbiWhRmkZSh" Ids="LATVjeiZhk1O8r2k9AS66k,O9o9yiPKX78LEbYtSSqW8v" />
                 <Link Id="H2sRoUDBr3nOtOUs5KSO3V" Ids="PUtk3kSNtbOLCnFhVnHesx,JT0UxvdESIEMJZpLqFH0AY" />
                 <Link Id="GZPJysmBo9NNIwVJUUK9rl" Ids="MoYibxj6tnpLwx3TYyWROw,FyDehZopAtPMsm9NWcNivw" />
+                <Link Id="HjZ40PbOcSYMtmz2VDyYz6" Ids="SMIkaxmzingMLbNHYRlrog,LQhRkYGAuHCQNW3iSXKuae" />
+                <Link Id="SJOwUQx2mNrMJ9BI1Jbfb6" Ids="FXGqbRsrujPLO4udrtLsCh,GKLsYR8zVtCLM2WL4UsLJj" />
+                <Link Id="PikG4YJovueNEMhyWQ3Rfd" Ids="CM2IU6RAhxYOO9kp02vFUs,F5wELj0oeafLq8o9fl4q2B" />
               </Patch>
             </Node>
             <!--
@@ -2810,7 +2830,7 @@
                   <Pin Id="GwLUS5wgeSROTXdPRaYtQT" Name="Notifications" Kind="InputPin" />
                   <Pin Id="AfsxcHg50GrP7erPPjOR0G" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="562,419,68,19" Id="DCeNgIpTbN2Ln7E3ILZ8Pu">
+                <Node Bounds="563,423,68,19" Id="DCeNgIpTbN2Ln7E3ILZ8Pu">
                   <p:NodeReference LastCategoryFullName="Main.Utils" LastSymbolSource="UIElements.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="MouseState" />
@@ -2838,13 +2858,13 @@
           <Link Id="PRXJ9iqQyotNvOGA0MYf6z" Ids="HlFaK9y09YmOl6ZFzTLUjL,E3XpJV4nrRUNk997xPfRWp" />
           <Link Id="MCTkRtct3KGLdQvIyPNY8e" Ids="BO6YBZaD3b7PKDelXHsA6M,PXeOWDRQj6HM36D1VfSMFn" />
           <Link Id="HRYSzcPGgToMBNZbWQAAfL" Ids="BO6YBZaD3b7PKDelXHsA6M,GwLUS5wgeSROTXdPRaYtQT" />
-          <Link Id="VWxvBjkt7djP8HHtOsTL0J" Ids="PM6Hvo3wXsUPlY1EPOiZIk,M3pIs6IZlqTL6x69Cd7Niz" />
           <Link Id="TY1kLmtktcWMlWTUPlRjJn" Ids="AfsxcHg50GrP7erPPjOR0G,RFf0nX2hVfzNkVHjW59x8F" />
           <Link Id="TfZKv4hbmPSQD2l1GO66kv" Ids="BO6YBZaD3b7PKDelXHsA6M,GPm5GPTFSHoO8tx8yaiafD" />
           <Link Id="Twtha3jNiLrM8MGc1QeYag" Ids="AOFTXQ9HexSM999dbMxp6l,EU89BtVk2hbNCiMWW8QqDO" />
           <Link Id="USR2ELOfD8wNHMHkf9tbhY" Ids="VicQNL3URFWNKvVc6FiEPG,AOFTXQ9HexSM999dbMxp6l" IsHidden="true" />
           <Link Id="KxTFKfCDtvEPbYbgLTKXqi" Ids="UzIfIYmzgnPLdgBhwTSiV3,Ja2Mtuc61YuMJXKe0jTupO" />
           <Link Id="NTKx3dAAPamLZZ8E62xvw1" Ids="Ja2Mtuc61YuMJXKe0jTupO,FUZXw9gBjtEP5qaNS9iLKH" IsHidden="true" />
+          <Link Id="OikPrSe5IVBODndA1ZRWfq" Ids="PM6Hvo3wXsUPlY1EPOiZIk,M3pIs6IZlqTL6x69Cd7Niz" />
         </Patch>
       </Node>
       <Canvas Id="Uw5kHqzf5PNLr51crslDBu" Name="Utils" Position="169,117">
@@ -6296,7 +6316,6 @@
           <Link Id="JQ2A8xvPtuaNKed49mY1ba" Ids="NYSO9hTm82fO4hBqNSyiTs,FfKfrfkypbEN8Kp2dRIeJy" IsHidden="true" />
           <Link Id="M9RTFzaDdMJOhbdLOyLNa4" Ids="AgTmMpBx3tXOgoDYyzWUgd,EPpQ0SJ3bRoNLggQjH06Cw" />
           <Link Id="LfNc76EnT7vNesDC3777Ju" Ids="Fz1dGWdZN9KNHAEikeTdby,KcrVVDjyvraMaRu0NNZqUK" IsHidden="true" />
-          <Link Id="Gz2Zs7g3DHhOP0BUkcrkn7" Ids="PTu5jM1O6kGNMx4SN8SpqQ,ShR3qbE5jbTMrVVh4SSYYe" />
           <Link Id="BIP4FLjHmDgL6A5JJ7DDmr" Ids="IvsYNCbxD13LYb8GUGth6l,F59IMw2WfMsLFVvqOUcPFz" />
           <Link Id="GR6UCDodC3vLlKBwKk8Yy8" Ids="TI2OWAmrhFDO1Ygcz7JNsB,VYEwzi8PZ6ULuBYK4UUJuN" />
           <Link Id="JLY8IrbS28tPYxpFCwqjXu" Ids="OWDAkBl8EDqM2ioankbXWo,CtUlUOO1moBMGgMocfIQ8s" />
@@ -6306,8 +6325,9 @@
           <Link Id="IDxnYjjoE2RL0SFrXBnyPg" Ids="Bz5267M8XQRL0M1dowTpyT,Hw1V0cZ6KFoO7MQThOcdYP" IsHidden="true" />
           <Link Id="FfNEYoBsJWlM2H3RF80QfI" Ids="LV1SBW3DF3CLRtI1TTfD7h,HrmsovfFIJMM3MldjU7DDZ" />
           <Link Id="D8utnXywkf4PTr4ataAa89" Ids="P7IqDJX1mNcPszWwkS1gWA,Sq83CamZxuGPtJCLFyEKVP" />
-          <Link Id="UqkAEB7uYHOP7lHCMbhga6" Ids="IgIDi7lTkqwOIt1TSnyq16,Bz5267M8XQRL0M1dowTpyT" />
           <Link Id="Vi2vUNcVwz3MiJQB7r4aQb" Ids="KcrVVDjyvraMaRu0NNZqUK,A9cQxN10qqrO18huluKk8i" />
+          <Link Id="SfVc3e9i44SN8u8sV8SbNy" Ids="IgIDi7lTkqwOIt1TSnyq16,Bz5267M8XQRL0M1dowTpyT" />
+          <Link Id="PbAjMQjVjf0MPR1iMPdE67" Ids="PTu5jM1O6kGNMx4SN8SpqQ,ShR3qbE5jbTMrVVh4SSYYe" />
         </Patch>
       </Node>
       <!--
@@ -6760,8 +6780,8 @@
           <Link Id="F3wR2cmXPL7MVAscQ2dn0D" Ids="FLYhc0kzlQpMxrbMtCecUs,AKCMZUv7sXyMkz53bTUXRH" IsHidden="true" />
           <Link Id="DM3HLduCpE6OqjYtOgszr5" Ids="DkuaRKPNUzbOKgM5qVGN3h,HcVJMKJXg0ZPeJDMEjxRLx" />
           <Link Id="J7zmViwFGibNM0wiFe21Xd" Ids="Km3yaXDq3L8LIPqMM6SnXk,BTr2B9542pNNwhK3Xy2R4x" />
-          <Link Id="EPLKD6HXCAOO7OHuqxLD2k" Ids="MdoFHAhFRs1P5VkUtpCVcQ,IvxtXAdMqckQQQFNoD8jM6" />
-          <Link Id="FMI7OnY8YZaMYnhiWPCM9T" Ids="OIfnOqFyLXILtvB5wmXtwS,OPLxj5aMDHnM9RP0dFnzE5" />
+          <Link Id="DVWEYmtOLrSPOotKpbzkj0" Ids="MdoFHAhFRs1P5VkUtpCVcQ,IvxtXAdMqckQQQFNoD8jM6" />
+          <Link Id="OPqhS1IRGPvLgz1K50iMp7" Ids="OIfnOqFyLXILtvB5wmXtwS,OPLxj5aMDHnM9RP0dFnzE5" />
         </Patch>
       </Node>
       <!--

--- a/vl/UIElements.vl
+++ b/vl/UIElements.vl
@@ -1418,8 +1418,22 @@
                 </TypeReference>
               </p:Interfaces>
               <Patch Id="V4MV8PjEz5DL8aBPw33ecm">
-                <Canvas Id="AHjLRCZ2xyAQW5Mer76jV8" CanvasType="Group" />
-                <Patch Id="OFKH3wVHZ36PA2UlRTmJC6" Name="Create" />
+                <Canvas Id="AHjLRCZ2xyAQW5Mer76jV8" CanvasType="Group">
+                  <ControlPoint Id="Sc1t3np8ve9Nnkgm1rFgx0" Bounds="614,248" />
+                  <Pad Id="Pn4o6hkuXC8Ms8sNj7Ak9a" SlotId="RzaKFt2UDs5MyNLtUTnjJh" Bounds="614,287" />
+                  <Pad Id="HHN7ESzrLQiLxVhTbOu0b1" SlotId="IEKTIpvhiKMQJBWwodW4FO" Bounds="735,287">
+                    <p:ValueBoxSettings />
+                  </Pad>
+                  <ControlPoint Id="F8HYkchzbL3PFWsRNWK7qI" Bounds="735,248" />
+                  <ControlPoint Id="Gg5czGma29WMSd06KX72QY" Bounds="518,472" />
+                  <ControlPoint Id="Q01nfPYCvPfPY2tugTj8Dc" Bounds="662,472" />
+                  <ControlPoint Id="RIfkH13QPg0NO36o8pZemA" Bounds="858,472" />
+                  <ControlPoint Id="UV07Pzq3wTrPZbH8jZem6n" Bounds="1028,472" />
+                </Canvas>
+                <Patch Id="OFKH3wVHZ36PA2UlRTmJC6" Name="Create" ParticipatingElements="RdgXKDdnX4qM7SnbQnMOjg">
+                  <Pin Id="SF0E3Gkq7WVOd9RXSGOQO3" Name="Properties" Kind="InputPin" />
+                  <Pin Id="DIiZApTAXNxNZgBrYsGzF4" Name="State Reference" Kind="InputPin" Bounds="739,240" />
+                </Patch>
                 <!--
 
     ************************  ************************
@@ -1427,7 +1441,31 @@
 -->
                 <ProcessDefinition Id="EgM1w94qlK3OFjMjGGNjxW" IsHidden="true">
                   <Fragment Id="Jc9QEDld4eUMpXGjTCTxlj" Patch="OFKH3wVHZ36PA2UlRTmJC6" Enabled="true" />
+                  <Fragment Id="E5A9qdOCQkcLY9dTwijrfP" Patch="VK7pGqAiHi6PJKSyc14XHB" Enabled="true" />
                 </ProcessDefinition>
+                <Link Id="QkKVlLG5sTJLb3ADDKttpT" Ids="SF0E3Gkq7WVOd9RXSGOQO3,Sc1t3np8ve9Nnkgm1rFgx0" IsHidden="true" />
+                <Slot Id="RzaKFt2UDs5MyNLtUTnjJh" Name="Properties">
+                  <p:TypeAnnotation>
+                    <Choice Kind="TypeFlag" Name="SliderProperties" />
+                  </p:TypeAnnotation>
+                </Slot>
+                <Link Id="RdgXKDdnX4qM7SnbQnMOjg" Ids="Sc1t3np8ve9Nnkgm1rFgx0,Pn4o6hkuXC8Ms8sNj7Ak9a" />
+                <Slot Id="IEKTIpvhiKMQJBWwodW4FO" Name="Reference">
+                  <p:TypeAnnotation>
+                    <Choice Kind="TypeFlag" Name="IInteractionState" />
+                  </p:TypeAnnotation>
+                </Slot>
+                <Link Id="O1STntPYclVLPeDMWLU1Ng" Ids="F8HYkchzbL3PFWsRNWK7qI,HHN7ESzrLQiLxVhTbOu0b1" />
+                <Link Id="LCcdtHoYO7oQH9VbuDTdNn" Ids="DIiZApTAXNxNZgBrYsGzF4,F8HYkchzbL3PFWsRNWK7qI" IsHidden="true" />
+                <Patch Id="VK7pGqAiHi6PJKSyc14XHB" Name="ProcessNotification">
+                  <Pin Id="V4nTaygOvRaM97As4sGXv5" MergeId="145629" Name="Notification" Kind="InputPin" />
+                  <Pin Id="LmpDiJtQ1eANxbkJVwoSPI" MergeId="145630" Name="MouseState" Kind="InputPin" />
+                  <Pin Id="CDmPR5Pst7ZPJQMzjlh4DN" MergeId="145631" Name="KeyboardState" Kind="InputPin" />
+                </Patch>
+                <Link Id="H8ftCzCz7NGMfqccVuUFyj" Ids="LmpDiJtQ1eANxbkJVwoSPI,Q01nfPYCvPfPY2tugTj8Dc" IsHidden="true" />
+                <Link Id="Cys2vgfrXfROR7EcXSqfgS" Ids="CDmPR5Pst7ZPJQMzjlh4DN,RIfkH13QPg0NO36o8pZemA" IsHidden="true" />
+                <Link Id="CVjFYcWZw9nLYL6nj48ZbH" Ids="V4nTaygOvRaM97As4sGXv5,Gg5czGma29WMSd06KX72QY" IsHidden="true" />
+                <Link Id="MvpQhbg8ZUOP1FPjP5tfPy" Ids="CDmPR5Pst7ZPJQMzjlh4DN,UV07Pzq3wTrPZbH8jZem6n" IsHidden="true" />
               </Patch>
             </Node>
           </Canvas>


### PR DESCRIPTION
Hello natan, 

Thanks for sharing those, pretty (pretty) deep and very interesting to learn.
I added the ability for sliders to have a default value that can be recalled via middle-clic. As a consequence, sliders can now only be dragged via left-drag. I also thought they could be fine-tuned via right-drag, but that'd be an other PR.

I also took the liberty to relink the nodes in the Spreading demo, they were still referencing the ones with the old names (UIxxx).

What would you think of that ?

Cheers.