### PR TITLE
NUnit tests and update to 2020.2

### DIFF
--- a/src/Elementa.sln
+++ b/src/Elementa.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.705
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30204.135
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elementa", "Elementa\Elementa.csproj", "{2FA67B37-61A1-4043-9D7E-4F8E7F6D8EE3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elementa", "Elementa\Elementa.csproj", "{2FA67B37-61A1-4043-9D7E-4F8E7F6D8EE3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NUnitTests", "NUnitTests\src\NUnitTests.csproj", "{73DE3C85-7476-44B3-ABE1-0BD75101F1A6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{2FA67B37-61A1-4043-9D7E-4F8E7F6D8EE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2FA67B37-61A1-4043-9D7E-4F8E7F6D8EE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2FA67B37-61A1-4043-9D7E-4F8E7F6D8EE3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73DE3C85-7476-44B3-ABE1-0BD75101F1A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73DE3C85-7476-44B3-ABE1-0BD75101F1A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73DE3C85-7476-44B3-ABE1-0BD75101F1A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73DE3C85-7476-44B3-ABE1-0BD75101F1A6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Elementa/Elementa.csproj
+++ b/src/Elementa/Elementa.csproj
@@ -6,6 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="ExCSS-Core" Version="4.0.5" />
-    <PackageReference Include="VL.Core" Version="2019.1.0-0286-g306c78279b" />
+    <PackageReference Include="VL.Core" Version="2020.2.0" />
   </ItemGroup>
 </Project>

--- a/src/NUnitTests/src/NUnitTests.csproj
+++ b/src/NUnitTests/src/NUnitTests.csproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <VLPackageBasePath>..\</VLPackageBasePath>
+    <PackageId>$(AssemblyName)</PackageId>
+    <Description>Test for my library</Description>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.14.0" />
+    <PackageReference Include="VL.Meta.Gamma" Version="2020.1.4" />
+    <PackageReference Include="VL.TestLib" Version="2020.1.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageFile Include="*.vl" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="*.vl">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/NUnitTests/src/NUnitTests.csproj
+++ b/src/NUnitTests/src/NUnitTests.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.14.0" />
-    <PackageReference Include="VL.Meta.Gamma" Version="2020.1.4" />
-    <PackageReference Include="VL.TestLib" Version="2020.1.4" />
+    <PackageReference Include="VL.Meta.Gamma" Version="2020.2.0" />
+    <PackageReference Include="VL.TestLib" Version="2020.2.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageFile Include="*.vl" />

--- a/src/NUnitTests/src/PatchTests.cs
+++ b/src/NUnitTests/src/PatchTests.cs
@@ -21,7 +21,7 @@ namespace MyTests
         static string[] Packs = new string[]{ 
         
         //  FIX ME !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            @"C:\Program Files\vvvv\vvvv_gamma_2020.1.4\lib\packs",
+            @"C:\Program Files\vvvv\vvvv_gamma_2020.2.0\lib\packs",
 
         };
 

--- a/src/NUnitTests/src/PatchTests.cs
+++ b/src/NUnitTests/src/PatchTests.cs
@@ -1,0 +1,124 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Internal;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using VL.Lang;
+using VL.Lang.Symbols;
+using VL.Model;
+using VVVV.NuGetAssemblyLoader;
+
+namespace MyTests
+{
+    [TestFixture]
+    public class PatchTests
+    {       
+        // FIX ME
+        //                       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        const string PacksPath = @"C:\Program Files\vvvv\vvvv_gamma_2020.1.4\lib\packs";
+        //                       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+
+        /// <summary>
+        /// Yield all your vl docs
+        /// </summary>
+        public static IEnumerable<string> NormalPatches()
+        {
+            var currentDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+            // get out of src/VL.DemoLib/bin/whatnot
+            var mainLibPath = Path.GetFullPath(Path.Combine(currentDirectory, @"..\..\..\..\..\..\..")); 
+
+            foreach (var file in Directory.GetFiles(mainLibPath, "*.vl", SearchOption.AllDirectories))
+                yield return file;
+        }
+
+
+        public static readonly VLSession Session;
+
+        static PatchTests()
+        {
+            // TODO: Should we add more?
+            AssemblyLoader.AddPackageRepositories(PacksPath);
+
+            // Setup session
+            if (SynchronizationContext.Current == null)
+                SynchronizationContext.SetSynchronizationContext(new WindowsFormsSynchronizationContext());
+            Session = new VLSession("gamma", SynchronizationContext.Current, includeUserPackages: false)
+            {
+                CheckSolution = false,
+                IgnoreDynamicEnumErrors = true,
+                NoCache = true,
+                KeepTargetCode = false
+            };
+        }
+
+
+
+
+
+        static Solution FCompiledSolution;
+
+
+        /// <summary>
+        /// Checks if the document comes with compile time errors (e.g. red nodes). Doesn't actually run the patches.
+        /// </summary>
+        /// <param name="filePath"></param>
+        [TestCaseSource(nameof(NormalPatches))]
+        public static void IsntRed(string filePath)
+        {
+            var solution = FCompiledSolution ?? (FCompiledSolution = Compile(NormalPatches()));
+            var document = solution.GetOrAddDocument(filePath);
+
+            // Check document structure
+            Assert.True(document.IsValid);
+
+            // Check dependenices
+            foreach (var dep in document.GetDocSymbols().Dependencies)
+                Assert.IsFalse(dep.RemoteSymbolSource is Dummy, $"Couldn't find dependency {dep}. Press F6 to build all library projects!");
+
+            // Check all containers and process node definitions, including application entry point
+            CheckNodes(document.AllTopLevelDefinitions);
+        }
+
+        static Solution Compile(IEnumerable<string> docs)
+        {
+            var solution = Session.CurrentSolution;
+            foreach (var f in docs)
+                solution = solution.GetOrAddDocument(f).Solution;
+            return solution.WithFreshCompilation();
+        }
+
+        public static void CheckNodes(IEnumerable<Node> nodes)
+        {
+            Parallel.ForEach(nodes, definition =>
+            {
+                var definitionSymbol = definition.GetSymbol() as IDefinitionSymbol;
+                Assert.IsNotNull(definitionSymbol, $"No symbol for {definition}.");
+                var errorMessages = definitionSymbol.Messages.Where(m => m.Severity == MessageSeverity.Error);
+                Assert.That(errorMessages.None(), () => $"{definition}: {string.Join(Environment.NewLine, errorMessages)}");
+                Assert.IsFalse(definitionSymbol.IsUnused, $"The symbol of {definition} is marked as unused.");
+            });
+        }
+
+
+
+
+        // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        // Running Tests patches not supported yet. We for now can only check for compile time errors (like red nodes)
+
+
+        /// <summary>
+        /// Yield all test patches that shall run
+        /// </summary>
+        public static IEnumerable<string> TestPatches()
+        {
+            yield return $@"C:\dev\vl-libs\VL.DemoLib\src\NUnitTests\tests\tests.vl";
+        }
+    }
+}

--- a/src/NUnitTests/src/PatchTests.cs
+++ b/src/NUnitTests/src/PatchTests.cs
@@ -17,38 +17,46 @@ namespace MyTests
 {
     [TestFixture]
     public class PatchTests
-    {       
-        // FIX ME
-        //                       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        const string PacksPath = @"C:\Program Files\vvvv\vvvv_gamma_2020.1.4\lib\packs";
-        //                       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    {
+        static string[] Packs = new string[]{ 
+        
+        //  FIX ME !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+            @"C:\Program Files\vvvv\vvvv_gamma_2020.1.4\lib\packs",
+
+        };
 
 
-        /// <summary>
-        /// Yield all your vl docs
-        /// </summary>
+
         public static IEnumerable<string> NormalPatches()
         {
-            var currentDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-
-            // get out of src/VL.DemoLib/bin/whatnot
-            var mainLibPath = Path.GetFullPath(Path.Combine(currentDirectory, @"..\..\..\..\..\..\..")); 
-
-            foreach (var file in Directory.GetFiles(mainLibPath, "*.vl", SearchOption.AllDirectories))
+            // Yield all your VL docs
+            foreach (var file in Directory.GetFiles(MainLibPath, "*.vl", SearchOption.AllDirectories))
                 yield return file;
         }
 
 
+
         public static readonly VLSession Session;
+        public static string MainLibPath;
+        public static string RepositoriesPath;
 
         static PatchTests()
         {
-            // TODO: Should we add more?
-            AssemblyLoader.AddPackageRepositories(PacksPath);
+            var currentDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            MainLibPath = Path.GetFullPath(Path.Combine(currentDirectory, @"..\..\..\..\..\..\.."));
+            RepositoriesPath = Path.GetFullPath(Path.Combine(MainLibPath, @".."));
 
-            // Setup session
+            foreach (var pack in Packs)
+                AssemblyLoader.AddPackageRepositories(pack);
+
+            // Also add the "vl-libs" folder. The folder that contains our library.
+            AssemblyLoader.AddPackageRepositories(RepositoriesPath);
+
+
             if (SynchronizationContext.Current == null)
                 SynchronizationContext.SetSynchronizationContext(new WindowsFormsSynchronizationContext());
+
+
             Session = new VLSession("gamma", SynchronizationContext.Current, includeUserPackages: false)
             {
                 CheckSolution = false,

--- a/src/NUnitTests/src/Properties/AssemblyInfo.cs
+++ b/src/NUnitTests/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿using NUnit.Framework;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2707f9b1-1b67-488c-9e08-37eb274ca43a")]
+
+[assembly: Apartment(ApartmentState.STA)]

--- a/src/NUnitTests/src/UnitTests.cs
+++ b/src/NUnitTests/src/UnitTests.cs
@@ -1,0 +1,19 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace MyTests
+{
+    public class UnitTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [Test]
+        public void Test1()
+        {
+            Assert.AreEqual(1 + 1, 2, "An old contract people tell their kids about just failed. Math is useless from now on.");
+        }
+    }
+}


### PR DESCRIPTION
please merge this back. 
It's an update to a new vvvv gamma version and it comes with a convenient way of testing your patches for errors.

Just open the solution with Visual Studio, go to the Test Explorer and run all. You'll see which documents are red. 